### PR TITLE
시군구 목록 고도화를 위한 Redis 추가

### DIFF
--- a/src/main/java/com/wanted/yamyam/api/location/service/LocationService.java
+++ b/src/main/java/com/wanted/yamyam/api/location/service/LocationService.java
@@ -55,7 +55,7 @@ public class LocationService {
     }
 
     private List<Location> getLocationsFromRedis() {
-        return (List<Location>) redisTemplate.opsForValue().get("locations");
+        return (List<Location>) redisTemplate.opsForValue().get(KEY);
     }
 
 }

--- a/src/main/java/com/wanted/yamyam/domain/location/entity/Location.java
+++ b/src/main/java/com/wanted/yamyam/domain/location/entity/Location.java
@@ -10,12 +10,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Location {
+public class Location implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/wanted/yamyam/global/config/RedisConfig.java
+++ b/src/main/java/com/wanted/yamyam/global/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.wanted.yamyam.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("yamyam-redis", 6379);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,10 @@ spring:
   servlet:
     multipart:
       max-file-size: 32KB
+  data:
+    redis:
+      connect-timeout: 2s
+      timeout: 1s
 
 
 


### PR DESCRIPTION
## 작업 내용

시군구 목록 조회 고도화를 위해 Redis를 추가하였습니다.

## 작업 설명

- [`9f7defa`](https://github.com/pre-onboarding/yamyam/commit/9f7defad48730799336aeba3afa6d73816d262e4)
  - Redis 관련 설정을 추가하였습니다. Spring Data Redis 사용 시 선택 가능한 Redis Client는 `Lettuce`와 `Jedis`가 있는데, 선택 기준으로 삼을만한 것들([Jedis vs. Lettuce: An Exploration](https://redis.com/blog/jedis-vs-lettuce-an-exploration/))이 모르는 내용이 많아서 Spring Data Redis 공식 문서([링크](https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/#redis:template))에서 예제에 사용되는 Lettuce로 사용하였습니다.
- [`14e71b1`](https://github.com/pre-onboarding/yamyam/commit/14e71b1b3e15eabc61c51ae32a10f3caf68a394e)
  - 시군구 데이터 저장 시 redis에도 함께 저장하고, 조회 시에 redis에 없으면 기존 데이터베이스에서 데이터를 불러와 저장한 후 반환하도록 작성하였습니다.

## 테스트

시군구 데이터 조회 API에 대해 부하 테스트를 아주 간단하게만 해봤는데, 너무 간단하게 해서 그런가 큰 차이는 없습니다. 최대응답 속도가 25ms vs 81ms로 Redis 미사용 시 예외적으로 가끔 튀어오르는 경우가 있지만, 사람이 인지할만한 정도는 아니고, 평균 응답 속도는 7ms vs 9ms 로 2ms 밖에 차이나지 않습니다.

JMeter를 처음 사용해봐서 사용법 좀 더 보고, 추후에 테스트 결과 추가적으로 공유하겠습니다.

### Redis 사용한 경우

![image](https://github.com/pre-onboarding/yamyam/assets/37972432/a25f0220-a15c-4316-9008-841f3d6ab6e7)

### Redis 사용하지 않은 경우

![image](https://github.com/pre-onboarding/yamyam/assets/37972432/3fe5dcd1-d7cc-4956-a894-9804fda25f24)

## 추가 테스트

이번에는 tomcat 최대 thread 수를 200개로 늘려주고, 15초 동안 10000번 요청하는 경우를 테스트 해봤습니다. 그나마 Redis가 버텨주기는 합니다. 왠만큼 큰 서비스 아니면, Redis를 응답 속도 올리는데 사용하는건 과한게 아닌가 싶기도 하네요.

### Redis 사용한 경우

![image](https://github.com/pre-onboarding/yamyam/assets/37972432/5808355e-e74f-4b70-9d0d-dfb5ff53e759)

### Redis 사용하지 않은 경우

![image](https://github.com/pre-onboarding/yamyam/assets/37972432/adea5a9f-cefa-4b73-8153-9568f1f44d8e)
