### PR TITLE
discord webhook을 이용한 점심 맛집 추천 기능 추가

### DIFF
--- a/src/main/java/com/wanted/yamyam/YamyamApplication.java
+++ b/src/main/java/com/wanted/yamyam/YamyamApplication.java
@@ -2,8 +2,12 @@ package com.wanted.yamyam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
+@EnableConfigurationProperties
 public class YamyamApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/wanted/yamyam/api/member/task/MemberScheduledTask.java
+++ b/src/main/java/com/wanted/yamyam/api/member/task/MemberScheduledTask.java
@@ -1,0 +1,77 @@
+package com.wanted.yamyam.api.member.task;
+
+import com.wanted.yamyam.api.store.dto.DiscordWebhook;
+import com.wanted.yamyam.api.store.dto.StoreResponse;
+import com.wanted.yamyam.api.store.service.StoreService;
+import com.wanted.yamyam.domain.member.entity.Member;
+import com.wanted.yamyam.domain.member.repo.MemberRepository;
+import com.wanted.yamyam.global.config.DiscordConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+/**
+ * 사용자와 관련된 정기적인 작업을 정의하는 클래스입니다.
+ * @author 정성국
+ */
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class MemberScheduledTask {
+
+    private final MemberRepository memberRepository;
+    private final StoreService storeService;
+    private final DiscordConfig discordConfig;
+    private final RestTemplate restTemplate;
+
+    /**
+     * 점심 추천 서비스 사용을 체크한 사용자에게 매일 점심 시간에 주변의 맛집을 추천합니다.
+     * @author 정성국
+     */
+    @Scheduled(cron = "0 30 11 * * ?", zone = "Asia/Seoul")
+    public void recommendLunch() {
+        List<Member> members = memberRepository.findAllByUseRecommendLunch(true);
+        members.forEach(member -> {
+            List<StoreResponse> stores = getTop5StoresByDistance(member.getLat(), member.getLon(), 500.0);
+            var discordWebhook = getDiscordWebhookForRecommendLunch(stores);
+            HttpStatusCode statusCode = restTemplate.postForEntity(
+                    discordConfig.getWebhookUrl(), discordWebhook, String.class).getStatusCode();
+
+            log.info("recommend lunch for " + member.getUsername() +
+                    ", response HTTP Status Code from discord: " + statusCode.value());
+        });
+    }
+
+    private List<StoreResponse> getTop5StoresByDistance(double lat, double lon, double range) {
+        return storeService.storeList("distance", 0, 5,
+                Double.toString(lat), Double.toString(lon), range).getStores();
+    }
+
+    private DiscordWebhook getDiscordWebhookForRecommendLunch(List<StoreResponse> stores) {
+        String message;
+        if (stores.isEmpty()) {
+            // TODO: 범위를 넓혀 검색한 후 가장 가까운 맛집의 거리와 함께 알려주기
+            message = "주변에 맛집이 없네요. ㅜㅜ";
+        } else {
+            message = "오늘의 근처 점심 맛집을 추천드립니다.\n" + getRecommendedStoreSummary(stores);
+        }
+        return DiscordWebhook.builder()
+                .username("YamYam")
+                .content(message)
+                .build();
+    }
+
+    private String getRecommendedStoreSummary(List<StoreResponse> stores) {
+        return stores.stream()
+                .map(StoreResponse::toString)
+                .collect(Collectors.joining("\n\n"));
+    }
+
+}

--- a/src/main/java/com/wanted/yamyam/api/member/task/MemberScheduledTask.java
+++ b/src/main/java/com/wanted/yamyam/api/member/task/MemberScheduledTask.java
@@ -39,7 +39,7 @@ public class MemberScheduledTask {
     public void recommendLunch() {
         List<Member> members = memberRepository.findAllByUseRecommendLunch(true);
         members.forEach(member -> {
-            List<StoreResponse> stores = getTop5StoresByDistance(member.getLat(), member.getLon(), 500.0);
+            List<StoreResponse> stores = getTop5StoresByDistance(member.getLat(), member.getLon(), 0.5);
             var discordWebhook = getDiscordWebhookForRecommendLunch(stores);
             HttpStatusCode statusCode = restTemplate.postForEntity(
                     discordConfig.getWebhookUrl(), discordWebhook, String.class).getStatusCode();

--- a/src/main/java/com/wanted/yamyam/api/store/dto/DiscordWebhook.java
+++ b/src/main/java/com/wanted/yamyam/api/store/dto/DiscordWebhook.java
@@ -1,0 +1,19 @@
+package com.wanted.yamyam.api.store.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Builder
+public record DiscordWebhook(
+        @JsonInclude
+        String username,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        String avatar_url,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        String content,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        List<DiscordWebhookEmbed> embeds
+) implements Serializable { }

--- a/src/main/java/com/wanted/yamyam/api/store/dto/DiscordWebhookEmbed.java
+++ b/src/main/java/com/wanted/yamyam/api/store/dto/DiscordWebhookEmbed.java
@@ -1,0 +1,64 @@
+package com.wanted.yamyam.api.store.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Builder
+public record DiscordWebhookEmbed (
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        Author author,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        String title,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        String url,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        String description,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        Integer color,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        List<Field> fields,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        Image thumbnail,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        Image image,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        Footer footer
+
+) implements Serializable {
+    @Builder
+    public record Author (
+            @JsonInclude
+            String name,
+            @JsonInclude(JsonInclude.Include.NON_EMPTY)
+            String url,
+            @JsonInclude(JsonInclude.Include.NON_EMPTY)
+            String icon_url
+    ) {}
+
+    @Builder
+    public record Field (
+            @JsonInclude
+            String name,
+            @JsonInclude
+            String value,
+            @JsonInclude(JsonInclude.Include.NON_EMPTY)
+            Boolean inline
+    ) implements Serializable {}
+
+    @Builder
+    public record Image (
+            @JsonInclude
+            String url
+    ) implements Serializable {}
+
+    @Builder
+    public record Footer (
+            @JsonInclude
+            String text,
+            @JsonInclude(JsonInclude.Include.NON_EMPTY)
+            String icon_url
+    ) implements Serializable {}
+}

--- a/src/main/java/com/wanted/yamyam/api/store/dto/StoreResponse.java
+++ b/src/main/java/com/wanted/yamyam/api/store/dto/StoreResponse.java
@@ -29,4 +29,11 @@ public class StoreResponse {
         this.category = category;
         this.rating = rating;
     }
+
+    @Override
+    public String toString() {
+        return "· 상호명: %s / 주소: %s / 종류: %s / 평점: %s / 거리: %s km"
+                .formatted(name, address, category,
+                        Double.toString(rating).substring(0, 3), Double.toString(distance).substring(0, 4));
+    }
 }

--- a/src/main/java/com/wanted/yamyam/domain/member/entity/Member.java
+++ b/src/main/java/com/wanted/yamyam/domain/member/entity/Member.java
@@ -27,4 +27,13 @@ public class Member {
 
     @Column
     private String username;
+
+    @Column
+    private double lat;
+
+    @Column
+    private double lon;
+
+    @Column
+    private boolean useRecommendLunch;
 }

--- a/src/main/java/com/wanted/yamyam/domain/member/repo/MemberRepository.java
+++ b/src/main/java/com/wanted/yamyam/domain/member/repo/MemberRepository.java
@@ -3,6 +3,9 @@ package com.wanted.yamyam.domain.member.repo;
 import com.wanted.yamyam.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberRepository extends JpaRepository<Member,Long> {
 
+    List<Member> findAllByUseRecommendLunch(boolean useRecommendLunch);
 }

--- a/src/main/java/com/wanted/yamyam/global/config/AppConfig.java
+++ b/src/main/java/com/wanted/yamyam/global/config/AppConfig.java
@@ -1,0 +1,21 @@
+package com.wanted.yamyam.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+}

--- a/src/main/java/com/wanted/yamyam/global/config/DiscordConfig.java
+++ b/src/main/java/com/wanted/yamyam/global/config/DiscordConfig.java
@@ -1,0 +1,16 @@
+package com.wanted.yamyam.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("discord")
+@Getter
+@Setter
+public class DiscordConfig {
+
+    private String webhookUrl;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,5 +37,8 @@ spring:
     multipart:
       max-file-size: 32KB
 
+discord:
+  webhookUrl: ${DISCORD_WEBHOOK_URL}
+
 
 


### PR DESCRIPTION
## 작업 내용

점심 시간을 12:00으로 가정하고, 30분 전인 11:30 에 discord 채널로 사용자 주변의 맛집 목록 5개를 추천하도록 하였습니다.

## 작업 설명

- [`6202940`](https://github.com/pre-onboarding/yamyam/commit/620294049589b6e5ea52d1c1529b31ef81631adf)
  - Discord Webhook 전송용 DTO를 추가하였습니다. discord webhook 양식에 맞춘 이름을 사용하기 위해 변수 이름에 underscore(_)를 사용하였습니다.
  - Webhook URL은 악용될 수 있으므로, 속성으로 따로 뺐습니다.
  - Webhook 요청을 위해 RestTemplate을 Bean으로 추가하였습니다. @myoungjinseo 님과 충돌할 수도 있을 것 같습니다.
- [`13b6d87`](https://github.com/pre-onboarding/yamyam/commit/13b6d8795267533f376101cd674890386d695f38)
  - @ks12b0000 현준님이 작성한 맛집 검색을 이용하여, 사용자 기준 500m 이내의 맛집 5개를 가져오도록 하였습니다.
  - `@Scheduled` annotiation을 이용하여 매일 오전 11시 30분에 메시지가 전달되도록 하였습니다.

## 테스트

![image](https://github.com/pre-onboarding/yamyam/assets/37972432/2e91b830-b4b1-456a-9384-d542dd4cb577)

## 기타

- 개인화된 메시지인데, 채널로 보내는게 좀 안맞는거 같습니다.
- 스케줄러 테스트는 해본적이 없어서 월요일(2023-11-06)에 작업할 예정입니다.