### PR TITLE
feat: 맛집 상세정보 조회 기능

### DIFF
--- a/src/main/java/com/wanted/yamyam/api/review/dto/StoreByReviewListResponse.java
+++ b/src/main/java/com/wanted/yamyam/api/review/dto/StoreByReviewListResponse.java
@@ -1,0 +1,24 @@
+package com.wanted.yamyam.api.review.dto;
+
+import com.wanted.yamyam.domain.member.entity.Member;
+import com.wanted.yamyam.domain.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StoreByReviewListResponse {
+
+    private Long memberId;
+
+    private int score;
+
+    private String content;
+
+    public StoreByReviewListResponse(Review review) {
+        this.memberId = review.getMember().getId();
+        this.score = review.getScore();
+        this.content = review.getContent();
+    }
+}

--- a/src/main/java/com/wanted/yamyam/api/review/service/ReviewService.java
+++ b/src/main/java/com/wanted/yamyam/api/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.wanted.yamyam.api.review.service;
 
+import com.wanted.yamyam.api.review.dto.StoreByReviewListResponse;
 import com.wanted.yamyam.domain.member.repo.MemberRepository;
 import com.wanted.yamyam.domain.review.entity.Review;
 import com.wanted.yamyam.domain.review.entity.ReviewId;
@@ -10,6 +11,9 @@ import com.wanted.yamyam.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -44,6 +48,18 @@ public class ReviewService {
         // 이미 작성한 리뷰가 존재하는 경우
         if (reviewRepository.existsById(new ReviewId(review.getMember(), review.getStore())))
             throw new ErrorException(ErrorCode.DUPLICATE_REVIEW);
+    }
+
+    /**
+     * storeId로 맛집에 리뷰 리스트를 조회해서 리스트를 반환한다.
+     * @param storeId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public List<StoreByReviewListResponse> reviewList(Long storeId) {
+        List<StoreByReviewListResponse> responses = reviewRepository.findByStoreId(storeId).stream().map(StoreByReviewListResponse::new).collect(Collectors.toList());
+
+        return responses;
     }
 
 }

--- a/src/main/java/com/wanted/yamyam/api/review/service/ReviewService.java
+++ b/src/main/java/com/wanted/yamyam/api/review/service/ReviewService.java
@@ -57,6 +57,7 @@ public class ReviewService {
      */
     @Transactional(readOnly = true)
     public List<StoreByReviewListResponse> reviewList(Long storeId) {
+        storeRepository.findById(storeId).orElseThrow(() -> new ErrorException(ErrorCode.NON_EXISTENT_STORE));
         List<StoreByReviewListResponse> responses = reviewRepository.findByStoreId(storeId).stream().map(StoreByReviewListResponse::new).collect(Collectors.toList());
 
         return responses;

--- a/src/main/java/com/wanted/yamyam/api/store/controller/StoreController.java
+++ b/src/main/java/com/wanted/yamyam/api/store/controller/StoreController.java
@@ -1,5 +1,9 @@
 package com.wanted.yamyam.api.store.controller;
 
+import com.wanted.yamyam.api.review.dto.StoreByReviewListResponse;
+import com.wanted.yamyam.api.review.service.ReviewService;
+import com.wanted.yamyam.api.store.dto.StoreDetailAndReviewListResponse;
+import com.wanted.yamyam.api.store.dto.StoreDetailResponse;
 import com.wanted.yamyam.api.store.service.StoreService;
 import com.wanted.yamyam.api.store.dto.StoreListResponse;
 import lombok.RequiredArgsConstructor;
@@ -7,10 +11,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,11 +23,21 @@ public class StoreController {
 
     private final StoreService storeService;
 
+    private final ReviewService reviewService;
+
     @GetMapping
     public ResponseEntity storeList(@RequestParam String sort, @RequestParam int page, @RequestParam int pageCount, @RequestParam String lat, @RequestParam String lon, @RequestParam double range) {
         StoreListResponse response = storeService.storeList(sort, page, pageCount, lat, lon, range);
 
         return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/{storeId}")
+    public ResponseEntity storeDetail(@PathVariable Long storeId) {
+        StoreDetailResponse storeDetail = storeService.storeDetail(storeId);
+        List<StoreByReviewListResponse> reviewList = reviewService.reviewList(storeId);
+
+        return ResponseEntity.ok().body(new StoreDetailAndReviewListResponse(storeDetail, reviewList));
     }
 
 }

--- a/src/main/java/com/wanted/yamyam/api/store/dto/StoreDetailAndReviewListResponse.java
+++ b/src/main/java/com/wanted/yamyam/api/store/dto/StoreDetailAndReviewListResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.yamyam.api.store.dto;
+
+import com.wanted.yamyam.api.review.dto.StoreByReviewListResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class StoreDetailAndReviewListResponse {
+
+    private StoreDetailResponse store;
+
+    private List<StoreByReviewListResponse> reviews;
+
+}

--- a/src/main/java/com/wanted/yamyam/api/store/dto/StoreDetailResponse.java
+++ b/src/main/java/com/wanted/yamyam/api/store/dto/StoreDetailResponse.java
@@ -1,0 +1,38 @@
+package com.wanted.yamyam.api.store.dto;
+
+import com.wanted.yamyam.api.review.dto.StoreByReviewListResponse;
+import com.wanted.yamyam.domain.store.entity.Store;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class StoreDetailResponse {
+
+    private Long id;
+
+    private double lat;
+
+    private double lon;
+
+    private String name;
+
+    private String address;
+
+    private String category;
+
+    private double rating;
+
+
+    public StoreDetailResponse(Store store) {
+        this.id = store.getId();
+        this.lat = store.getLat();
+        this.lon = store.getLon();
+        this.name = store.getName();
+        this.address = store.getAddress();
+        this.category = store.getCategory();
+        this.rating = store.getRating();
+    }
+}

--- a/src/main/java/com/wanted/yamyam/api/store/service/StoreService.java
+++ b/src/main/java/com/wanted/yamyam/api/store/service/StoreService.java
@@ -1,8 +1,13 @@
 package com.wanted.yamyam.api.store.service;
 
+import com.wanted.yamyam.api.review.dto.StoreByReviewListResponse;
+import com.wanted.yamyam.api.review.service.ReviewService;
+import com.wanted.yamyam.api.store.dto.StoreDetailResponse;
 import com.wanted.yamyam.api.store.dto.StoreResponse;
 import com.wanted.yamyam.api.store.dto.StoreListResponse;
+import com.wanted.yamyam.domain.store.entity.Store;
 import com.wanted.yamyam.domain.store.repo.StoreRepository;
+import com.wanted.yamyam.global.exception.ErrorCode;
 import com.wanted.yamyam.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -139,5 +144,21 @@ public class StoreService {
         double newRating = (oldRating * oldRatingTotalCount + review.getScore()) / (oldRatingTotalCount + 1);
         storeRepository.updateRatingById(review.getStore().getId(), newRating);
         return newRating;
+    }
+
+    /**
+     * 맛집 상세 정보
+     * storeId로 맛집을 상세 정보를 조회한다. 만약 존재하지 않는 맛집이면 예외처리.
+     * storeId로 조회한 맛집에 리뷰 리스트를 조회한다.
+     * 조회한 맛집 상세 정보, 리뷰 리스트를 반환한다.
+     * @param storeId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public StoreDetailResponse storeDetail(Long storeId) {
+        Optional<Store> store = Optional.ofNullable(storeRepository.findById(storeId).orElseThrow(() -> new ErrorException(ErrorCode.NON_EXISTENT_STORE)));
+        StoreDetailResponse response = new StoreDetailResponse(store.get());
+
+        return response;
     }
 }

--- a/src/main/java/com/wanted/yamyam/domain/review/repo/ReviewRepository.java
+++ b/src/main/java/com/wanted/yamyam/domain/review/repo/ReviewRepository.java
@@ -4,6 +4,10 @@ import com.wanted.yamyam.domain.review.entity.Review;
 import com.wanted.yamyam.domain.review.entity.ReviewId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, ReviewId> {
     long countByStoreId(Long storeId);
+
+    List<Review> findByStoreId(Long storeId);
 }

--- a/src/test/java/com/wanted/yamyam/api/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/wanted/yamyam/api/review/service/ReviewServiceTest.java
@@ -1,0 +1,66 @@
+package com.wanted.yamyam.api.review.service;
+
+import com.wanted.yamyam.api.review.dto.StoreByReviewListResponse;
+import com.wanted.yamyam.domain.member.entity.Member;
+import com.wanted.yamyam.domain.review.entity.Review;
+import com.wanted.yamyam.domain.review.repo.ReviewRepository;
+import com.wanted.yamyam.domain.store.entity.Store;
+import com.wanted.yamyam.domain.store.repo.StoreRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @DisplayName("맛집 리뷰 리스트")
+    @Test
+    @Transactional(readOnly = true)
+    void reviewList() {
+        // given
+        Store store = new Store(1L, 37.1375168981, 127.0756273255, "카페밀", "경기도 오산시 밀머리로 48 (원동)", "중국식", 3.0);
+        Long storeId = 1L;
+        Member member = new Member(1L, "email@gmail.com", "askjdlk1", null, null);
+        Review review = new Review(member, store, 3, "맛있어요~");
+        List<Review> list = new ArrayList<>();
+        list.add(review);
+
+        // stub
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+        when(reviewRepository.findByStoreId(storeId)).thenReturn(list);
+
+        // when
+        List<StoreByReviewListResponse> responses = reviewService.reviewList(storeId);
+
+        // then
+        assertAll(
+                () -> assertThat(responses.get(0).getMemberId()).isEqualTo(review.getMember().getId()),
+                () -> assertThat(responses.get(0).getScore()).isEqualTo(review.getScore()),
+                () -> assertThat(responses.get(0).getContent()).isEqualTo(review.getContent())
+        );
+
+    }
+
+}

--- a/src/test/java/com/wanted/yamyam/api/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/wanted/yamyam/api/store/controller/StoreControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -47,5 +48,21 @@ class StoreControllerTest {
         // then
         resultActions.andExpect(status().isOk());
         resultActions2.andExpect(status().isOk());
+    }
+
+    @DisplayName("맛집 목록조회")
+    @Test
+    @Transactional(readOnly = true)
+    void storeDetail() throws Exception {
+        // given
+        Long storeId = 1L;
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/v1/stores/" + storeId)
+                .characterEncoding("UTF-8")
+        );
+
+        // then
+        resultActions.andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/wanted/yamyam/api/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/wanted/yamyam/api/store/controller/StoreControllerTest.java
@@ -50,7 +50,7 @@ class StoreControllerTest {
         resultActions2.andExpect(status().isOk());
     }
 
-    @DisplayName("맛집 목록조회")
+    @DisplayName("맛집 상세 정보 조회")
     @Test
     @Transactional(readOnly = true)
     void storeDetail() throws Exception {

--- a/src/test/java/com/wanted/yamyam/api/store/service/StoreServiceTest.java
+++ b/src/test/java/com/wanted/yamyam/api/store/service/StoreServiceTest.java
@@ -1,5 +1,6 @@
 package com.wanted.yamyam.api.store.service;
 
+import com.wanted.yamyam.api.store.dto.StoreDetailResponse;
 import com.wanted.yamyam.api.store.dto.StoreListResponse;
 import com.wanted.yamyam.api.review.dto.ReviewRequest;
 import com.wanted.yamyam.domain.member.entity.Member;
@@ -7,6 +8,7 @@ import com.wanted.yamyam.domain.review.entity.Review;
 import com.wanted.yamyam.domain.review.repo.ReviewRepository;
 import com.wanted.yamyam.domain.store.entity.Store;
 import com.wanted.yamyam.domain.store.repo.StoreRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +16,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -60,7 +64,7 @@ class StoreServiceTest {
         var testScore = 5;
         var testContent = "맛있어요!!";
         var testUsername = "식신";
-        var oldRating = "2.5";
+        var oldRating = 2.5;
         var oldRatingTotalCount = 30L;
         var testMember = Member.builder().id(1L).username(testUsername).build();
         var testStore = Store.builder().id(1L).rating(oldRating).build();
@@ -78,6 +82,33 @@ class StoreServiceTest {
         var newRating = "2.6";
 
         assertThat(storeService.updateRating(testReview)).isEqualTo(newRating);
+
+    }
+
+    @DisplayName("맛집 상세정보")
+    @Test
+    @Transactional
+    void storeDetail() {
+        // given
+        Store store = new Store(1L, 37.1375168981, 127.0756273255, "카페밀", "경기도 오산시 밀머리로 48 (원동)", "중국식", 3.0);
+        Long storeId = 1L;
+
+        // stub
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+
+        // when
+        StoreDetailResponse response = storeService.storeDetail(storeId);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getId()).isEqualTo(store.getId()),
+                () -> assertThat(response.getLat()).isEqualTo(store.getLat()),
+                () -> assertThat(response.getLon()).isEqualTo(store.getLon()),
+                () -> assertThat(response.getName()).isEqualTo(store.getName()),
+                () -> assertThat(response.getAddress()).isEqualTo(store.getAddress()),
+                () -> assertThat(response.getCategory()).isEqualTo(store.getCategory()),
+                () -> assertThat(response.getRating()).isEqualTo(store.getRating())
+        );
 
     }
 }

--- a/src/test/java/com/wanted/yamyam/api/store/service/StoreServiceTest.java
+++ b/src/test/java/com/wanted/yamyam/api/store/service/StoreServiceTest.java
@@ -85,7 +85,7 @@ class StoreServiceTest {
 
     }
 
-    @DisplayName("맛집 상세정보")
+    @DisplayName("맛집 상세 정보 조회")
     @Test
     @Transactional
     void storeDetail() {


### PR DESCRIPTION
## 작업 내용
storeId로 맛집 상세정보 조회하는 기능 추가했습니다.

## 작업 설명
- [`1a13e76`](https://github.com/pre-onboarding/yamyam/pull/22/commits/1a13e76477c8b87f570aa27f5d8c0d272dd51192): 맛집 상세정보 조회 기능 추가
- [`c93d06a`](https://github.com/pre-onboarding/yamyam/pull/22/commits/c93d06a8d1448cdbff0d99bf3f01eaaa976edf47): 맛집에 달린 리뷰 리스트 조회 시 맛집이 존재하는지 예외처리 추가(맛집 상세정보 조회 시 예외처리 해놨지만, 나중에 리뷰 리스트 조회를 따로 사용할 로직이 생길때를 대비해서 넣어둠.)
- [`af45258`](https://github.com/pre-onboarding/yamyam/pull/22/commits/af452580dd34e8ac52d6673e8e78af4894965521): 맛집 상세정보 조회, 맛집 리뷰 리스트 테스트 코드 추가

### 통합 테스트
<img width="256" alt="스크린샷 2023-11-06 오후 4 15 13" src="https://github.com/pre-onboarding/yamyam/assets/102012155/14db32ee-708e-4f0f-83d7-ed50b60d148c">
<img width="256" alt="스크린샷 2023-11-06 오후 4 15 38" src="https://github.com/pre-onboarding/yamyam/assets/102012155/a0002f1b-69e2-467b-8fb9-722b54c3400f">

### 수동 테스트 
- [`1a13e76`](https://github.com/pre-onboarding/yamyam/pull/22/commits/1a13e76477c8b87f570aa27f5d8c0d272dd51192): 맛집 상세정보 조회 
<img width="839" alt="스크린샷 2023-11-05 오후 6 10 56" src="https://github.com/pre-onboarding/yamyam/assets/102012155/b95fece4-f912-4c58-a09b-4e95ba392585">

