### PR TITLE
맛집 평가에 사용자 id와 맛집 id 반영

### DIFF
--- a/src/main/java/com/wanted/yamyam/api/review/dto/ReviewResponse.java
+++ b/src/main/java/com/wanted/yamyam/api/review/dto/ReviewResponse.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 
 public record ReviewResponse(
         long memberId,
-        long storeId,
+        String storeId,
         String username,
         int score,
         String content

--- a/src/main/java/com/wanted/yamyam/api/review/service/ReviewService.java
+++ b/src/main/java/com/wanted/yamyam/api/review/service/ReviewService.java
@@ -6,6 +6,7 @@ import com.wanted.yamyam.domain.review.entity.Review;
 import com.wanted.yamyam.domain.review.entity.ReviewId;
 import com.wanted.yamyam.domain.review.repo.ReviewRepository;
 import com.wanted.yamyam.domain.store.entity.Store;
+import com.wanted.yamyam.domain.store.entity.StoreId;
 import com.wanted.yamyam.domain.store.repo.StoreRepository;
 import com.wanted.yamyam.global.exception.ErrorCode;
 import com.wanted.yamyam.global.exception.ErrorException;
@@ -41,7 +42,7 @@ public class ReviewService {
         validateData(review);
         var reviewEntity = Review.builder()
                 .member(memberRepository.getReferenceById(review.getMember().getId()))
-                .store(storeRepository.getReferenceById(review.getStore().getId()))
+                .store(storeRepository.getReferenceById(new StoreId(review.getStore().getName(), review.getStore().getAddress())))
                 .score(review.getScore())
                 .content(review.getContent()).build();
         return reviewRepository.save(reviewEntity);
@@ -49,7 +50,7 @@ public class ReviewService {
 
     private void validateData(Review review) {
         // 존재하지 않는 맛집인 경우
-        if (!storeRepository.existsById(review.getStore().getId()))
+        if (!storeRepository.existsById(new StoreId(review.getStore().getName(), review.getStore().getAddress())))
             throw new ErrorException(ErrorCode.NON_EXISTENT_STORE);
 
         // 이미 작성한 리뷰가 존재하는 경우


### PR DESCRIPTION
## 작업 내용

추가된 사용자 id 및 변경된 맛집 id를 반영하여 맛집 평가 생성 로직을 수정하였습니다.

## 작업 설명

- [`baf4013`](https://github.com/pre-onboarding/yamyam/commit/baf4013c38bf8b1e5776b7e17f08952ca547e6ef)
  - 사용자 id는 일단, `@AuthenticationPrincipal`로 받아올 수 있을지 확신이 안서서 `SecurityContextHolder`에서 가져왔습니다.
  - 맛집 id는 회의한대로 name과 address를 `:` 로 분리하거나 합쳐서 사용하였습니다.

### 테스트

@ks12b0000 현준님과 겹치는 부분이 있어 테스트는 생략하였습니다.

## 기타

- 병합하고 테스트가 필요합니다.